### PR TITLE
Replace bad data and use nansum

### DIFF
--- a/hetdex_api/extract.py
+++ b/hetdex_api/extract.py
@@ -56,9 +56,13 @@ def sclean(waves, fiber_data, fiber_error, mask,
     
     Parameters 
     ----------
-    fiber_data, fiber_error : array
+    fiber_data, fiber_error : 1D array
         the data and error arrays of
         the fiber
+    mask : 1D array
+        the mask for this fiber (so
+        the bad data can be unmasked
+        after replacement)
     npix : int
         the size of the +/- pixel
         to average to find the 
@@ -66,6 +70,12 @@ def sclean(waves, fiber_data, fiber_error, mask,
     error_scale : float
         scale the error by this
         when replacing
+
+    Returns
+    -------
+    fiber_data_out, fiber_error_out, mask : 1D array
+        the input data with bad values 
+        replaced and unmasked
     """
     fiber_data_out = np.copy(fiber_data)
     fiber_error_out = np.copy(fiber_error)

--- a/hetdex_api/extract.py
+++ b/hetdex_api/extract.py
@@ -65,7 +65,7 @@ def sclean(waves, fiber_data, fiber_error, mask,
         after replacement)
     npix : int
         the size of the +/- pixel
-        to average to find the 
+        range to average to find the 
         replacement value
     error_scale : float
         scale the error by this

--- a/hetdex_api/flux_limits/shot_sensitivity.py
+++ b/hetdex_api/flux_limits/shot_sensitivity.py
@@ -75,12 +75,16 @@ class ShotSensitivity(object):
     d25scale : float
         Sets the multiplier for the galaxy masks
         applied (default 3.0)
+    sclean_bad : bool
+        Replace bad data using the sclean
+        tool (see hetdex_api.extract:Extract)
     verbose : bool
         Print information about the flux limit model
         to the screen
     """
     def __init__(self, datevshot, release=None, flim_model=None, rad=3.5, 
-                 ffsky=False, wavenpix=3, d25scale=3.0, verbose=False): 
+                 ffsky=False, wavenpix=3, d25scale=3.0, verbose=False,
+                 sclean_bad = True): 
 
         self.conf = HDRconfig()
         self.extractor = Extract()
@@ -90,6 +94,7 @@ class ShotSensitivity(object):
         self.ffsky = ffsky
         self.wavenpix = wavenpix
         self.verbose = verbose
+        self.sclean_bad = sclean_bad
 
         if verbose:
             print("shotid: ", self.shotid)
@@ -566,7 +571,8 @@ class ShotSensitivity(object):
                 weights = weights/norm
 
                 result = self.extractor.get_spectrum(data, error, fmask, weights,
-                                                     remove_low_weights = False)
+                                                     remove_low_weights = False,
+                                                     sclean_bad = self.sclean_bad)
                 
                 spectrum_aper, spectrum_aper_error = [res for res in result] 
  


### PR DESCRIPTION
Implements a version of `sclean` to replace bad data by an average. Also handles NaNs in spectral elements by using `nansum` and then scaling up by the fraction of NaN values. 


