### PR TITLE
remove zarray normalisation

### DIFF
--- a/hetdex_api/extract.py
+++ b/hetdex_api/extract.py
@@ -712,7 +712,7 @@ class Extract:
         Z = np.reshape(Z, xgrid.shape)
 
         zarray = np.array([Z, xgrid, ygrid])
-        zarray[0] /= zarray[0].sum()
+        #zarray[0] /= zarray[0].sum()
        
         return zarray
 
@@ -1162,10 +1162,12 @@ class Extract:
 
         if not fac:
             scale = np.abs(psf[1][0, 1] - psf[1][0, 0])
-            # area = 0.75 ** 2 * np.pi
-            area = 1.7671458676442586
-            fac = area / scale ** 2
-        
+            #area = 0.75 ** 2 * np.pi
+            #area = 1.7671458676442586
+            #fac = area / scale ** 2
+            # scale to fiber size already included in moffat_psf_integration?
+            fac = 1.0
+
         # Avoid using a loop to speed things up, uses more memory though
         SX = np.tile(ifux, len(self.wave)).reshape(len(self.wave), len(ifux)).T
         SY = np.tile(ifuy, len(self.wave)).reshape(len(self.wave), len(ifuy)).T
@@ -1214,7 +1216,8 @@ class Extract:
         for i in np.arange(len(self.wave)):
             S[:, 0] = ifux - self.ADRx[i] - xc
             S[:, 1] = ifuy - self.ADRy[i] - yc
-            weights[:, i] = I(S[:, 0], S[:, 1]) * area / scale ** 2
+            # don't rescale by area factor - already done in moffat_psf_integration?
+            weights[:, i] = I(S[:, 0], S[:, 1]) #* area / scale ** 2
 
         return weights
 

--- a/hetdex_api/flux_limits/shot_sensitivity.py
+++ b/hetdex_api/flux_limits/shot_sensitivity.py
@@ -584,8 +584,13 @@ class ShotSensitivity(object):
                     # Account for NaN spectral bins
                     goodfrac = 1.0 - sum(isnan(spectrum_aper_error[ilo:ihi]))/(ihi - ilo)
 
-                    sum_sq = \
-                        sqrt(nansum(square(spectrum_aper_error[ilo:ihi]/goodfrac)))
+                    if all(isnan(spectrum_aper_error[ilo:ihi])):
+                        sum_sq = badval
+                    else:
+                        sum_sq = \
+                            sqrt(nansum(square(spectrum_aper_error[ilo:ihi]/goodfrac)))
+
+
                     norm_all.append(nansum(norm[ilo:ihi])/len(norm[ilo:ihi]))
                     noise.append(sum_sq)
                 else:
@@ -709,7 +714,12 @@ class ShotSensitivity(object):
             f50s = self.get_f50(ra, dec, lambda_, sncut, linewidth = linewidth)
 
         try:
+            # to stop bad values breaking interpolation
+            bad = (f50s > 998)
+            f50s[bad] = 1e-16
             fracdet = self.sinterp(flux, f50s, lambda_, sncut)
+            fracdet[bad] = 0.0
+            f50s[bad] = 999.0
         except IndexError as e:
             print("Interpolation failed!")
             print(min(flux), max(flux), min(f50s), max(f50s))


### PR DESCRIPTION
Remove the zarray normalisation and instead avoid double scaling by the pixel area to fiber area factors (in the end it only makes a very small difference). 