### PR TITLE
Fix bug in apcor and f50 when passing wave=None

### DIFF
--- a/hetdex_api/flux_limits/shot_sensitivity.py
+++ b/hetdex_api/flux_limits/shot_sensitivity.py
@@ -440,7 +440,7 @@ class ShotSensitivity(object):
         f50s = badval*ones(nsrc)
         mask = ones(nsrc)
         norm = ones(nsrc)
-        amp = array(["notinshot"]*nsrc)
+        amp = array(["notinshot00_0_multi_00_000_000_00_000"]*nsrc)
 
         if nsel > 0:
             for i in range(nsplit):  

--- a/hetdex_api/flux_limits/shot_sensitivity.py
+++ b/hetdex_api/flux_limits/shot_sensitivity.py
@@ -647,12 +647,12 @@ class ShotSensitivity(object):
                         
                 weights, I, fac = self.extractor.build_weights(xc, yc, ifux, ifuy, self.moffat, 
                                                                I=I, fac=fac, return_I_fac = True)
-                
-
+ 
                 # (See Greg Zeimann's Remedy code)
                 # normalized in the fiber direction
                 norm = sum(weights, axis=0) 
                 weights = weights/norm
+
 
                 result = self.extractor.get_spectrum(data, error, fmask, weights,
                                                      remove_low_weights = False,
@@ -708,6 +708,7 @@ class ShotSensitivity(object):
                 else:
                     logger.debug("Convolving with window to get flux limits versus wave")
 
+
                     # Use astropy convolution so NaNs are ignored
                     convolved_variance = convolve(square(spectrum_aper_error),
                                                   convolution_filter, 
@@ -720,14 +721,14 @@ class ShotSensitivity(object):
                                               convolution_filter, 
                                               normalize_kernel=True)
 
-
                     # To get mean account for the edges in
                     # the convolution
                     for iend in range(self.wavenpix):
-                        fac = filter_len/(filter_len + iend - self.wavenpix)
-                        convolved_norm[iend] *= fac
-                        convolved_norm[-iend - 1] *= fac
- 
+                        edge_fac = filter_len/(filter_len + iend - self.wavenpix)
+                        convolved_norm[iend] *= edge_fac
+                        convolved_norm[-iend - 1] *= edge_fac
+
+
                     # Mask wavelengths with too many bad pixels
                     # equivalent to nan_fib in the wave != None mode
                     wunorm = weights*norm

--- a/tests/test_flux_limits/test_shot_sensitivity.py
+++ b/tests/test_flux_limits/test_shot_sensitivity.py
@@ -112,10 +112,13 @@ def test_completeness(ra, dec, wave, flux, lw, exptd, flim_model):
 
     assert pytest.approx(c, rel=0.005) == exptd
 
+
+
 @pytest.mark.parametrize("ra, dec, sclean",
                           [
                             (201.5498985, 51.82207577, True),
                             (201.5498985, 51.82207577, False),
+
                           ]                           
                         )
 def test_wave_none_mode(ra, dec, sclean):
@@ -138,7 +141,6 @@ def test_wave_none_mode(ra, dec, sclean):
                                          waves, 5.0, 
                                          direct_sigmas=True)
 
-
     
     diff = (all_sigmas[0] - from_single_wave)/all_sigmas[0]
     diff_apcor = (apcor1[0] - apcor2)/apcor1[0]
@@ -150,6 +152,45 @@ def test_wave_none_mode(ra, dec, sclean):
     # test if good to within 0.05%
     assert nanmax(abs(diff_apcor)) < 5e-4
     assert nanmax(abs(diff)) < 5e-4
+
+
+@pytest.mark.parametrize("ras, decs",
+                         [
+                          (
+                           [229.95960512542143, 229.74236696267425],
+                           [53.8360578364009, 54.0562276323938]
+                          )
+                         ]
+                        )
+def test_wave_none_array(ras, decs):
+    """ 
+    As test_wave_none_mode but multiple 
+    ra/dec at once
+
+    """
+    s = ShotSensitivity("20200423v019")
+    
+    # All at once
+    f50_arr, apcor_arr, mask = s.get_f50(ras, decs, None, 1.0,
+                                         direct_sigmas = True)
+
+    waves = s.extractor.get_wave()
+
+    for i, (r, d) in enumerate(zip(ras, decs), 0):
+
+        f50, apcor = s.get_f50(r*ones(len(waves)), d*ones(len(waves)), 
+                               waves, 1.0,
+                               direct_sigmas = True)
+
+        diff = (f50 - f50_arr[i, :])/f50_arr[i, :]
+        diff_apcor = (apcor - apcor_arr[i, :])/apcor_arr[i, :]
+        
+        print(apcor)
+        print(apcor_arr[i, :])
+
+        # test if good to within 0.05%
+        assert nanmax(abs(diff_apcor)) < 5e-4
+        assert nanmax(abs(diff)) < 5e-4
 
 
 def test_chip_gap_mask():


### PR DESCRIPTION
A bug meant that all flux limits and aperture corrections generated from get_f50 when passing multiple RA/DEC values and wave=None would be wrong by a factor of about 0.857 due to accidentally using the same variable name twice.